### PR TITLE
Allow passing in a Mongoose connection

### DIFF
--- a/lib/express-mongodb.js
+++ b/lib/express-mongodb.js
@@ -38,6 +38,7 @@ var Session = new Schema({
  */
 
 var defaultOptions = {
+    connection: Mongoose.connection
     collection: 'session',
     clear_interval: -1
 };
@@ -48,12 +49,13 @@ module.exports = function (express) {
 
     function MongooseStore(options, cb) {
         var self = this;
+        var connection = options.connection || defaultOptions.connection;
         var collection = options.collection || defaultOptions.collection;
         var clear_interval = options.clear_interval || defaultOptions.clear_interval;
         options = options || {};
         Store.call(this, options);
         Mongoose.model(collection, Session);
-        self.collection = Mongoose.model(collection);
+        self.collection = connection.model(collection);
 
         self._getCollection = function(cb) {
             cb && cb(self.collection);


### PR DESCRIPTION
After reading: [Building with Node.js: Sessions](http://journal.michaelahlers.org/2013/01/building-with-nodejs-sessions.html) this seemed
like a good idea, and shouldn't break any backwards compatibility.
