### PR TITLE
Fixed missing comma causing Syntax Error

### DIFF
--- a/lib/express-mongodb.js
+++ b/lib/express-mongodb.js
@@ -38,7 +38,7 @@ var Session = new Schema({
  */
 
 var defaultOptions = {
-    connection: Mongoose.connection
+    connection: Mongoose.connection,
     collection: 'session',
     clear_interval: -1
 };


### PR DESCRIPTION
Missing comma is causing Syntax Error when requiring express-mongodb
